### PR TITLE
Fix python3 import

### DIFF
--- a/shitpy/dataStructures/__init__.py
+++ b/shitpy/dataStructures/__init__.py
@@ -1,1 +1,3 @@
-from list import *
+# from .list import *
+
+__all__ = ['list']

--- a/shitpy/dataTypes/__init__.py
+++ b/shitpy/dataTypes/__init__.py
@@ -1,1 +1,3 @@
-from int import *
+# from .int import *
+
+__all__ = ["int"]


### PR DESCRIPTION
Have change the code to reflect the changes to Python3's method of importing local modules.

Details are here: https://docs.python.org/3/tutorial/modules.html#importing-from-a-package 

The list details all of the modules to load when doing import *

Alternately the from .int import * could be used in the __init__.py file (left commented out).

Similar changes had to be made to the list one too.

These changes are compatible with Python 2, too.

Fixes #11 